### PR TITLE
Fix critical bugs and add evaluation features

### DIFF
--- a/cfg.py
+++ b/cfg.py
@@ -3,6 +3,7 @@ import argparse
 
 def parse_args():    
     parser = argparse.ArgumentParser()
+    parser.add_argument('-seed', type=int, default=24, help='random seed')
     parser.add_argument('-net', type=str, default='sam', help='net type')
     parser.add_argument('-baseline', type=str, default='unet', help='baseline net type')
     parser.add_argument('-encoder', type=str, default='default', help='encoder type')

--- a/dataset/__init__.py
+++ b/dataset/__init__.py
@@ -24,6 +24,7 @@ def get_dataloader(args):
     transform_train = transforms.Compose([
         transforms.Resize((args.image_size,args.image_size)),
         transforms.ToTensor(),
+        transforms.Lambda(lambda x: x * 255)
     ])
 
     transform_train_seg = transforms.Compose([
@@ -34,6 +35,7 @@ def get_dataloader(args):
     transform_test = transforms.Compose([
         transforms.Resize((args.image_size, args.image_size)),
         transforms.ToTensor(),
+        transforms.Lambda(lambda x: x * 255)
     ])
 
     transform_test_seg = transforms.Compose([

--- a/function.py
+++ b/function.py
@@ -144,6 +144,7 @@ def train_sam(args, net: nn.Module, optimizer, train_loader,
                 for n, value in net.image_encoder.named_parameters(): 
                     value.requires_grad = True
                     
+            origin_imgs = imgs.clone()        
             imgs = net.preprocess(imgs)        
             imge= net.image_encoder(imgs)
             with torch.no_grad():
@@ -215,7 +216,7 @@ def train_sam(args, net: nn.Module, optimizer, train_loader,
                     namecat = 'Train'
                     for na in name[:2]:
                         namecat = namecat + na.split('/')[-1].split('.')[0] + '+'
-                    vis_image(imgs,pred,masks, os.path.join(args.path_helper['sample_path'], namecat+'epoch+' +str(epoch) + '.jpg'), reverse=False, points=showp)
+                    vis_image(origin_imgs/255,pred,masks, os.path.join(args.path_helper['sample_path'], namecat+'epoch+' +str(epoch) + '.jpg'), reverse=False, points=showp)
 
             pbar.update()
 
@@ -306,6 +307,7 @@ def validation_sam(args, val_loader, epoch, net: nn.Module, clean_dir=True):
                 
                 '''test'''
                 with torch.no_grad():
+                    origin_imgs = imgs.clone()
                     imgs = net.preprocess(imgs)
                     imge= net.image_encoder(imgs)
                     if args.net == 'sam' or args.net == 'mobile_sam':
@@ -363,7 +365,7 @@ def validation_sam(args, val_loader, epoch, net: nn.Module, clean_dir=True):
                         ]:
                             img_name = na.split('/')[-1].split('.')[0]
                             namecat = namecat + img_name + '+'
-                        vis_image(imgs,pred, masks, os.path.join(args.path_helper['sample_path'], namecat+'epoch+' +str(epoch) + '.jpg'), reverse=False, points=showp)
+                        vis_image(origin_imgs/255,pred, masks, os.path.join(args.path_helper['sample_path'], namecat+'epoch+' +str(epoch) + '.jpg'), reverse=False, points=showp)
                     
 
                     temp = eval_seg(pred, masks, threshold)

--- a/function.py
+++ b/function.py
@@ -114,7 +114,7 @@ def train_sam(args, net: nn.Module, optimizer, train_loader,
                 coords_torch = torch.as_tensor(point_coords, dtype=torch.float, device=GPUdevice)
                 labels_torch = torch.as_tensor(point_labels, dtype=torch.int, device=GPUdevice)
                 if(len(point_labels.shape)==1): # only one point prompt
-                    coords_torch, labels_torch, showp = coords_torch[None, :, :], labels_torch[None, :], showp[None, :, :]
+                    coords_torch, labels_torch, showp = coords_torch.unsqueeze(1), labels_torch.unsqueeze(1), showp[None, :, :]
                 pt = (coords_torch, labels_torch)
 
             '''init'''
@@ -292,7 +292,7 @@ def validation_sam(args, val_loader, epoch, net: nn.Module, clean_dir=True):
                     coords_torch = torch.as_tensor(point_coords, dtype=torch.float, device=GPUdevice)
                     labels_torch = torch.as_tensor(point_labels, dtype=torch.int, device=GPUdevice)
                     if(len(point_labels.shape)==1): # only one point prompt
-                        coords_torch, labels_torch, showp = coords_torch[None, :, :], labels_torch[None, :], showp[None, :, :]
+                        coords_torch, labels_torch, showp = coords_torch.unsqueeze(1), labels_torch.unsqueeze(1), showp[None, :, :]
                     pt = (coords_torch, labels_torch)
 
                 '''init'''

--- a/function.py
+++ b/function.py
@@ -102,7 +102,7 @@ def train_sam(args, net: nn.Module, optimizer, train_loader,
 
                 imgs = torchvision.transforms.Resize((args.image_size,args.image_size))(imgs)
                 masks = torchvision.transforms.Resize((args.out_size,args.out_size))(masks)
-            showp = pt
+            showp = pt[..., [1, 0]]
 
             mask_type = torch.float32
             ind += 1
@@ -279,7 +279,7 @@ def validation_sam(args, val_loader, epoch, net: nn.Module, clean_dir=True):
                     imgs = torchvision.transforms.Resize((args.image_size,args.image_size))(imgs)
                     masks = torchvision.transforms.Resize((args.out_size,args.out_size))(masks)
                 
-                showp = pt
+                showp = pt[..., [1, 0]]
 
                 mask_type = torch.float32
                 ind += 1

--- a/function.py
+++ b/function.py
@@ -114,7 +114,7 @@ def train_sam(args, net: nn.Module, optimizer, train_loader,
                 coords_torch = torch.as_tensor(point_coords, dtype=torch.float, device=GPUdevice)
                 labels_torch = torch.as_tensor(point_labels, dtype=torch.int, device=GPUdevice)
                 if(len(point_labels.shape)==1): # only one point prompt
-                    coords_torch, labels_torch, showp = coords_torch.unsqueeze(1), labels_torch.unsqueeze(1), showp[None, :, :]
+                    coords_torch, labels_torch, showp = coords_torch.unsqueeze(1), labels_torch.unsqueeze(1), showp.unsqueeze(1)
                 pt = (coords_torch, labels_torch)
 
             '''init'''
@@ -295,7 +295,7 @@ def validation_sam(args, val_loader, epoch, net: nn.Module, clean_dir=True):
                     coords_torch = torch.as_tensor(point_coords, dtype=torch.float, device=GPUdevice)
                     labels_torch = torch.as_tensor(point_labels, dtype=torch.int, device=GPUdevice)
                     if(len(point_labels.shape)==1): # only one point prompt
-                        coords_torch, labels_torch, showp = coords_torch.unsqueeze(1), labels_torch.unsqueeze(1), showp[None, :, :]
+                        coords_torch, labels_torch, showp = coords_torch.unsqueeze(1), labels_torch.unsqueeze(1), showp.unsqueeze(1)
                     pt = (coords_torch, labels_torch)
 
                 '''init'''

--- a/function.py
+++ b/function.py
@@ -145,6 +145,7 @@ def train_sam(args, net: nn.Module, optimizer, train_loader,
                 for n, value in net.image_encoder.named_parameters(): 
                     value.requires_grad = True
                     
+            imgs = net.preprocess(imgs)        
             imge= net.image_encoder(imgs)
             with torch.no_grad():
                 if args.net == 'sam' or args.net == 'mobile_sam':
@@ -191,7 +192,7 @@ def train_sam(args, net: nn.Module, optimizer, train_loader,
                 )
                 
             # Resize to the ordered output size
-            pred = F.interpolate(pred,size=(args.out_size,args.out_size))
+            pred = F.interpolate(pred,size=(args.out_size,args.out_size), mode="bilinear", align_corners=False)
 
             loss = lossfunc(pred, masks)
 
@@ -303,6 +304,7 @@ def validation_sam(args, val_loader, epoch, net: nn.Module, clean_dir=True):
                 
                 '''test'''
                 with torch.no_grad():
+                    imgs = net.preprocess(imgs)
                     imge= net.image_encoder(imgs)
                     if args.net == 'sam' or args.net == 'mobile_sam':
                         se, de = net.prompt_encoder(
@@ -348,7 +350,7 @@ def validation_sam(args, val_loader, epoch, net: nn.Module, clean_dir=True):
                         )
 
                     # Resize to the ordered output size
-                    pred = F.interpolate(pred,size=(args.out_size,args.out_size))
+                    pred = F.interpolate(pred,size=(args.out_size,args.out_size), mode="bilinear", align_corners=False)
                     tot += lossfunc(pred, masks)
 
                     '''vis images'''

--- a/function.py
+++ b/function.py
@@ -219,7 +219,7 @@ def train_sam(args, net: nn.Module, optimizer, train_loader,
 
             pbar.update()
 
-    return loss
+    return epoch_loss / len(train_loader)
 
 def validation_sam(args, val_loader, epoch, net: nn.Module, clean_dir=True):
      # eval mode

--- a/function.py
+++ b/function.py
@@ -45,7 +45,6 @@ args = cfg.parse_args()
 GPUdevice = torch.device('cuda', args.gpu_device)
 pos_weight = torch.ones([1]).cuda(device=GPUdevice)*2
 criterion_G = torch.nn.BCEWithLogitsLoss(pos_weight=pos_weight)
-seed = torch.randint(1,11,(args.b,7))
 
 torch.backends.cudnn.benchmark = True
 loss_function = DiceCELoss(to_onehot_y=True, softmax=True)

--- a/train.py
+++ b/train.py
@@ -39,6 +39,9 @@ def main():
 
     args = cfg.parse_args()
 
+    seed = args.seed
+    set_seed(seed)
+
     GPUdevice = torch.device('cuda', args.gpu_device)
 
     net = get_network(args, args.net, use_gpu=args.gpu, gpu_device=GPUdevice, distribution = args.distributed)

--- a/train.py
+++ b/train.py
@@ -99,7 +99,7 @@ def main():
 
     for epoch in range(settings.EPOCH):
 
-        if epoch and epoch < 5:
+        if epoch < 5:
             if args.dataset != 'REFUGE':
                 tol, (eiou, edice) = function.validation_sam(args, nice_test_loader, epoch, net, writer)
                 logger.info(f'Total score: {tol}, IOU: {eiou}, DICE: {edice} || @ epoch {epoch}.')

--- a/utils.py
+++ b/utils.py
@@ -1007,10 +1007,10 @@ def vis_image(imgs, pred_masks, gt_masks, save_path, reverse = False, points = N
                 else:
                     ps = np.round(points.cpu()/args.image_size * args.out_size).to(dtype = torch.int)
                 # gt_masks[i,:,points[i,0]-5:points[i,0]+5,points[i,1]-5:points[i,1]+5] = torch.Tensor([255, 0, 0]).to(dtype = torch.float32, device = torch.device('cuda:' + str(dev)))
-                for p in ps:
-                    gt_masks[i,0,p[i,0]-5:p[i,0]+5,p[i,1]-5:p[i,1]+5] = 0.5
-                    gt_masks[i,1,p[i,0]-5:p[i,0]+5,p[i,1]-5:p[i,1]+5] = 0.1
-                    gt_masks[i,2,p[i,0]-5:p[i,0]+5,p[i,1]-5:p[i,1]+5] = 0.4
+                for p in ps[i]:
+                    gt_masks[i,0,p[0]-5:p[0]+5,p[1]-5:p[1]+5] = 0.5
+                    gt_masks[i,1,p[0]-5:p[0]+5,p[1]-5:p[1]+5] = 0.1
+                    gt_masks[i,2,p[0]-5:p[0]+5,p[1]-5:p[1]+5] = 0.4
         if boxes is not None:
             for i in range(b):
                 # the next line causes: ValueError: Tensor uint8 expected, got torch.float32

--- a/utils.py
+++ b/utils.py
@@ -76,6 +76,17 @@ device = torch.device('cuda', args.gpu_device)
 # optimizerD = optim.Adam(netD.parameters(), lr=dis_lr, betas=(beta1, 0.999))
 '''end'''
 
+def set_seed(seed):
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+    
+    torch.backends.cudnn.deterministic = True
+    torch.backends.cudnn.benchmark = False
+    os.environ['PYTHONHASHSEED'] = str(seed)
+    
 def get_network(args, net, use_gpu=True, gpu_device = 0, distribution = True):
     """ return given network
     """

--- a/utils.py
+++ b/utils.py
@@ -1160,6 +1160,7 @@ def random_click(mask, point_labels = 1):
         point_labels = max_label
     # max agreement position
     indices = np.argwhere(mask == max_label) 
+    indices = indices[:, ::-1].copy()
     return point_labels, indices[np.random.randint(len(indices))]
 
 

--- a/utils.py
+++ b/utils.py
@@ -1035,6 +1035,7 @@ def eval_seg(pred,true_mask_p,threshold):
     pred: [b,2,h,w]
     '''
     b, c, h, w = pred.size()
+    pred = F.sigmoid(pred)
     if c == 2:
         iou_d, iou_c, disc_dice, cup_dice = 0,0,0,0
         for th in threshold:

--- a/utils.py
+++ b/utils.py
@@ -963,6 +963,9 @@ def vis_image(imgs, pred_masks, gt_masks, save_path, reverse = False, points = N
     if reverse == True:
         pred_masks = 1 - pred_masks
         gt_masks = 1 - gt_masks
+    else:
+        pred_masks = pred_masks.clone()
+        gt_masks = gt_masks.clone()
     if c == 2: # for REFUGE multi mask output
         pred_disc, pred_cup = pred_masks[:,0,:,:].unsqueeze(1).expand(b,3,h,w), pred_masks[:,1,:,:].unsqueeze(1).expand(b,3,h,w)
         gt_disc, gt_cup = gt_masks[:,0,:,:].unsqueeze(1).expand(b,3,h,w), gt_masks[:,1,:,:].unsqueeze(1).expand(b,3,h,w)


### PR DESCRIPTION
## Bug Fixes

### Bug1: random click (x, y) order
**Fixed coordinate order mismatch between point prompts and SAM's expectation.** 
In function `random_click` np.argwhere returns indices in (y, x) format, while SAM requires (x, y) format. The fixing will increase training performance and efficiency.

### Bug2: Incorrect GT_mask during validation
**Fixed GT mask modification issue during visualization that affected evaluation accuracy.**
In some validation epoch, `vis_image` is used for showing the prediction. But in `vis_image`, the `gt_masks` used in `eval_seg` is modified by `gt_masks[i,0,p[i,0]-5:p[i,0]+5,p[i,1]-5:p[i,1]+5] = 0.5`, because the passed `gt_masks` is not a *cloned* version. The bug changes the `gt_masks` by adding gray pixels on it wrongly and affects the validation result accuracy.

### Bug3: Align Pre/post-processing with SAM
**Added missing SAM pre/post-processing steps in training pipeline.**
For pre-processing, in original implementation, the image is transformed by `ToTensor`, which is resized to [0, 1]. While in SAM, an input image is in [0, 255] style, which is normalized with a pre-defined pixel-mean and pixel-std. For post-processing, bilinear interpolate is used to resize pred to mask shape instead of nearest. Add pre-processing to training pipeline to keep the same with SAM.

### Bug4: Random seed not taking effect properly
**Support set random seed for reproducibility.**
In `function.py`, `seed` is inited by `torch.randint(1,11,(args.b,7))`. While the `seed` is not used anywhere. The PR support user providing seed and set seed for torch, numpy and random. The fixed code can ensure reproducibility. 

### Bug5: Incorrect dimension expansion
**Fixed incorrect dimension expansion in one-point prompt scenarios.** 
In `function.py`, when one-point prompt is given, the code `coords_torch, labels_torch, showp = coords_torch[None, :, :], labels_torch[None, :], showp[None, :, :]` expand Tenser `B*N` to `1*B*N`. However, the following code in SAM (transformer), will expand the Tensor to `B*B*N` automaticaly. The original expansion operation wrongly forecasts all points to each in-batch data item in fact. The solution is expanding tensor in dim 1, i.e.,   `coords_torch, labels_torch, showp = coords_torch.unsqueeze(1), labels_torch.unsqueeze(1), showp.unsqueeze(1)`. The fixed operation expands the tensor from `B*N` to `B*1*N`, also aligning with `B*P*N` in multi-point scenarios.

### Bug6: Logging training loss for last-batch only
**Fixed training loss logging (last-batch -> average).**
In `train_sam`, the return is last-batch loss, written into logging file. The fixed code logs the average during training. 

### Bug7: Incorrect metrics calculation
**Change metric calculation from batch-level to item-level.** 
The `eval_seg` function  calculate the in-batch average metrics, and in `validation_sam`, the average metrics is averaged by validation steps. While, considering a case that the last-batch has only one-item, and other batches have 1024 items in each, the last-batch is over-weighted 1024 times and influence the metrics calculation. The fixed code takes this in consideration and calculate the item-level metrics.

### Bug8: Incorrect for-loop implementation in vis
**Fixed incorrect for-loop implementation in multi-point prompting scenarios.** The original for-loop is:
```
for i in range(b):
    ...
    for p in ps:
        operation(p[i, 0])
```
The ps is a tensor of Shape `B*P`, the two for-loop is both for batch-level loop and will cause Error when multi-point prompting. The fixing change the second for-loop to point-level loop.

## New Features

### Feat 1: Applied Sigmoid to predictions during evaluation to normalize values between 0-1
 Noting that the evaluation threshold is set to (0.1, 0.3, 0.5, 0.7, 0.9). If the pred range form ($- \inf$ to $+ \inf$), the threshold makes nonsense. So the fixing code applies Sigmoid to pred.

### Feat2: Evaluation before Training
To show SAM adapter's zero-shot performance and validate evaluation code correctness, the committed code conducts evaluation when `epoch == 0`.

## Impact
- Improved model reliability and evaluation accuracy
- More robust handling of various prompt scenarios
- Better metric calculation and logging
- Enhanced validation pipeline with zero-shot testing

## Experiments
### Dataset
To verified the committed code, experiments are also conducted on `ISIC` and a dataset called `SHAPE` created by @JaireYu. The `SHAPE` dataset is consisted of random multiple isolated Convex polygons and Ellipse drawn on 1024X1024 canvas.  The dataset is attached [here].([SHAPE.zip](https://github.com/user-attachments/files/19801001/SHAPE.zip))

### Results
##### IOU @ ISIC
|code version| SAM-Adapter | batch_size = 1| batch_size = 4|
|---| --- |--- |--- |
|origin code| Before Training| 13.71 | 19.58 |
|PR code|Before Training| 12.73 | 12.99 |
|origin code|Max in 5 epoch| 85.21 | 85.42|
|PR code|Max in 5 epoch| 86.10 | 86.75 |

##### IOU @ SHAPE
|code version| SAM-Adapter | batch_size = 1| batch_size = 4|
|---| --- |--- |--- |
|origin code| Before Training| 9.29 | 6.84 |
|PR code|Before Training|  81.61 | 81.20 |
|origin code|Max in 5 epoch| 80.69 | 14.23 |
|PR code|Max in 5 epoch|  96.92 | 97.58 |

Note: the above PR code evaluation does not include pred Sigmoid feature to make fair comparison.

### Analysis

The Model trained on PR code shows better or comparable performance without any training and with 5 epoch traing, especially on SHAPE dataset. Referring to BUG 1, the reason is that in ISIC, almost all masks are placed at center of the images, which means flipping (x, y) is acceptable. However, for the SHAPE data, the masks are placed randomly, flipping (x, y) is unacceptable. The following two images support this point.
|origin code (before training)|PR code (before training)|
|---| --- |
|![Clipboard_Screenshot_1744921211](https://github.com/user-attachments/assets/0768d728-f970-484e-8d75-0134a4701bf4)|![Clipboard_Screenshot_1744921177](https://github.com/user-attachments/assets/4bc5012b-d59b-4dcb-a29c-32ca302c43bc)|

Another interesting thing is: using the origin code, batch size = 4 performs much worse than batch size = 1 (14.23 v.s. 80.69). Referring to BUG 5, the reason is that all points in batch are gathered and fed into SAM. The incorrect data processing makes the model hard to converge. The following is the visualization:
|origin code (5 epoch)|PR code (5 epoch)|
|---| --- |
|![Clipboard_Screenshot_1744922997](https://github.com/user-attachments/assets/4c5d4181-9bae-4093-91ea-be7288c06d8a)|![Clipboard_Screenshot_1744923108](https://github.com/user-attachments/assets/e0c0a621-5364-46a2-8214-d42b9a279ba2)|

## Attention
Because the `net.preprocessing` (pixel-mean and pixel std normalization) is introduced in training pipeline, `get_decath_loader` may be needed to changed slightly.

Please review and test thoroughly before merging. 

Moreover, I noticed these fixes might affect some of the experimental results and conclusions in your paper. If you plan to update the paper or release a report addressing these corrections in the future, I would appreciate being involved in the discussion, as these modifications could be significant to the research findings.

Feel free to contact with me if you'd like to discuss the impact of these changes on the research conclusions. I'm happy to contribute further to ensure the academic record accurately reflects these important technical details.

Merge it and help the people in the research community!